### PR TITLE
Add support for Farming Sim 25

### DIFF
--- a/LeaseToOwn.lua
+++ b/LeaseToOwn.lua
@@ -64,7 +64,7 @@ end
 function LeaseToOwn:onVehicleListIndexChanged(index, count)
     logger:debug("LeaseToOwn:onVehicleListIndexChanged vehiclesList")
 
-    if g_inGameMenu.leasePurchase_Button ~= nil then
+    if g_inGameMenu.leasePurchase_Button ~= nil and #g_inGameMenu.vehiclesList.dataSource.vehicles > 0 then
         local vehicle = g_inGameMenu.vehiclesList.dataSource.vehicles[index].vehicle
         if vehicle:getPropertyState() == VehiclePropertyState.LEASED then
             g_inGameMenu.leasePurchase_Button:setDisabled(false)

--- a/LeaseToOwn.lua
+++ b/LeaseToOwn.lua
@@ -24,7 +24,7 @@ logger:setLevel(Logger.INFO)
 
 function LeaseToOwn:onFrameOpen()
     logger:debug("LeaseToOwn:onFrameOpen pageStatistics")
-    
+
     local clonedButton = g_inGameMenu.menuButton[1]:clone(self)
 
     clonedButton:setDisabled(true)
@@ -49,6 +49,8 @@ function LeaseToOwn:onFrameClose()
 end
 
 function LeaseToOwn:onIndexChanged(index, count)
+    logger:debug("LeaseToOwn:onIndexChanged vehiclesList")
+
     if g_inGameMenu.leasePurchase_Button ~= nil then
         local vehicle = g_inGameMenu.vehiclesList.dataSource.vehicles[index].vehicle
         if vehicle:getPropertyState() == VehiclePropertyState.LEASED then
@@ -84,10 +86,18 @@ function LeaseToOwn:onConfirm(confirm)
 
         local farm = g_farmManager:getFarmByUserId(g_currentMission.playerUserId)
         if farm ~= nil then
-            g_client:getServerConnection():sendEvent(LeaseToOwnEvent.new(LeaseToOwn.selectedVehicle,
-                                                                         farm.farmId,
-                                                                         LeaseToOwn.price))
+            local vehicle = LeaseToOwn.selectedVehicle
+            local price = LeaseToOwn.price
 
+            g_client:getServerConnection():sendEvent(LeaseToOwnEvent.new(vehicle,
+                                                                         farm.farmId,
+                                                                         price))
+
+            g_inGameMenu:exitMenu()
+
+            InfoDialog.show(string.format(g_i18n:getText("LeaseToOwn_leasePurchaseCompleted"),
+                               vehicle:getName(),
+                               g_i18n:formatMoney(price)))
         end
     end
 end

--- a/build.bat
+++ b/build.bat
@@ -1,7 +1,0 @@
-rem make ZIP archive
-tar.exe -a -c -f FS22_LeaseToOwn.zip Logger.lua LeaseToOwn.lua LeaseToOwnEvent.lua modDesc.xml icon_leasetoown.dds
-
-copy FS22_LeaseToOwn.zip FS22_LeaseToOwn_update.zip
-
-rem copy ZIP to FS22 mods folder
-xcopy /b/v/y FS22_LeaseToOwn.zip "D:\Users\Bodzio\Documents\My Games\FarmingSimulator2022\mods"

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,20 @@
+# Make ZIP archive
+tar.exe -a -c -f FS25_LeaseToOwn.zip Logger.lua LeaseToOwn.lua LeaseToOwnEvent.lua modDesc.xml icon_leasetoown.dds
+
+# Define the path to the "Documents" folder, user and language independent
+$documentsPath = [System.Environment]::GetFolderPath('MyDocuments')
+
+# Combine the "Documents" path with "My Games\FarmingSimulator2025\mods" folder
+$modsFolderPath = Join-Path -Path $documentsPath -ChildPath "My Games\FarmingSimulator2025\mods"
+
+# Check if the mods folder exists
+if (Test-Path -Path $modsFolderPath) {
+    # Copy ZIP to FS25 mods folder
+    Copy-Item -Path FS25_LeaseToOwn.zip -Destination $modsFolderPath -Force
+    Write-Output "Build and copied successfully."
+} else {
+    Write-Warning "The path '$modsFolderPath' does not exist."
+}
+
+Write-Host "Press any key to exit..."
+$x = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -2,7 +2,11 @@
 <modDesc descVersion="92">
     <author>Bodzio528</author>
     <version>1.0.2.0</version>
-	<contributors>Gonimy-Vetrom</contributors>
+	<contributors>
+        Gonimy-Vetrom
+        SyBozzDEV
+        ColinM9991
+    </contributors>
     <title>
         <en>Lease To Own</en>
         <de>Mietvertrag Mit Kaufklausel</de>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
-<modDesc descVersion="75">
+<modDesc descVersion="92">
     <author>Bodzio528</author>
-    <version>1.0.1.0</version>
+    <version>1.0.2.0</version>
 	<contributors>Gonimy-Vetrom</contributors>
     <title>
         <en>Lease To Own</en>
@@ -64,6 +64,7 @@ Mod does not interact with savegame files. No new savegame is required, and disa
 
 Changelog:
 1.0.1.0 Added translations
+1.0.2.0 FS25 support
 ]]></en>
         <de><![CDATA[
 Im Allgemeinen bezieht sich Mietkauf auf Methoden, bei denen ein Mietvertrag vorsieht, dass der Mieter die Immobilie schließlich kauft.
@@ -191,6 +192,7 @@ Changelog:
     <extraSourceFiles>
         <sourceFile filename="LeaseToOwn.lua" />
         <sourceFile filename="LeaseToOwnEvent.lua" />
+        <sourceFile filename="Logger.lua" />
     </extraSourceFiles>
 
     <l10n>
@@ -209,14 +211,6 @@ Changelog:
             <pl>Czy chcesz wykupić %s za %s?</pl>
             <uk>Викупити орендований %s за %s?</uk>
             <ru>Выкупить арендованный %s за %s?</ru>
-        </text>
-        <text name="LeaseToOwn_leasePurchaseQuestionHeader">
-            <en>Leased equipment purchase</en>
-            <de>Kauf von geleasten Geräten</de>
-            <fr>Achat de matériel loué</fr>
-            <pl>Wykup leasingowany sprzęt</pl>
-            <uk>Викуп орендованої техніки</uk>
-            <ru>Выкуп арендованной техники</ru>
         </text>
     </l10n>
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -212,6 +212,9 @@ Changelog:
             <uk>Викупити орендований %s за %s?</uk>
             <ru>Выкупить арендованный %s за %s?</ru>
         </text>
+        <text name="LeaseToOwn_leasePurchaseCompleted">
+            <en>You have purchased %s for %s</en>
+        </text>
     </l10n>
 
 </modDesc>


### PR DESCRIPTION
This adds support for Farming Sim 25 but there are some points which still need to be looked at. While I am a developer, I'm new to LUA and the Farming Sim API so I hope the proposed changes are satisfactory and up to your standards.

One of the changes which Farming Sim 25 brought in was the removal of the leased vehicles from the shop. This has moved to the Vehicles tab on the Statistics page. 

In Farming Sim 22 the Vehicles tab contained a non-interactive table, while Farming Sim 25 uses this as the primary source for managing vehicles including returning leased vehicles.

![image](https://github.com/user-attachments/assets/fbe21484-de83-4eed-8ace-c99a3357b5f4)

The proposed changes move the purchase button to the Statistics page so it appears when the frame is opened and removes the button on frame close. This hooks into the index-changed event on the vehicles list to enable and disable the button based on whether the vehicle for that index is leased.

![image](https://github.com/user-attachments/assets/eeac47a9-0529-472b-99c8-ae30c1755845)

![image](https://github.com/user-attachments/assets/aac8f2fa-3af1-4845-9f09-4c7d2e3ec625)

Unfortunately I haven't been able to test this in multiplayer as I'm a lone Farming Sim player but I have reused the same event to transfer vehicle ownership.

## Issues

The one issue at the moment is that, while vehicle ownership transfers, the vehicle list does not update until the menu is closed and re-opened. While I could overwrite the column text directly - I'm still digging around the FS25 API to see if there are any functions that GIANTS introduced which could be used to re-load the table data instead. This feels a better approach.

This issue also makes me think about potential scenarios in multiplayer where two players have the vehicle list open at the same time, though this may also be an issue with the FS22 shop based leasing approach if two players were to have the leased vehicles open at once - not sure.